### PR TITLE
enhance/sync_return_code

### DIFF
--- a/vcompute/common/scripts/ipmi_sim/common.py
+++ b/vcompute/common/scripts/ipmi_sim/common.py
@@ -123,6 +123,6 @@ def send_ipmitool_command(*cmds):
         err_message = "failed to send ipmitool command: {0}".format(dst_cmd)
         logger.error(err_message)
         lock.release()
-        return None
+        return -1
     lock.release()
     return stdout

--- a/vcompute/common/scripts/ipmi_sim/sdr.py
+++ b/vcompute/common/scripts/ipmi_sim/sdr.py
@@ -49,10 +49,6 @@ def read_sensor_raw_value(sensor_num, event_type="threshold"):
                                           hex(sensor_num))
     if result == -1:
         return 0
-    try:
-        value = result.split()[0]
-    except AttributeError:
-        return 0 # raw data can't be got, set raw value as '0'
     if event_type == "threshold":
         value = result.split()[0]
         info = "sensor num: {0} value: 0x{1}".format(hex(sensor_num), value)


### PR DESCRIPTION
Sync return code of send_ipmitool_command() to -1.
Return of None may lead split() exception in sdr.parse_sdrs().